### PR TITLE
refactor: refinar interface de lotes e aplicar restrições de permissão

### DIFF
--- a/frontend/src/app/features/lote/lote.html
+++ b/frontend/src/app/features/lote/lote.html
@@ -10,14 +10,16 @@
         Listagem de lotes corporativos em tempo real
       </p>
     </div>
-    <button (click)="irParaNovoLote()"
-      class="flex items-center gap-2 bg-[#00E5FF] hover:bg-[#00E5FF]/90 text-black px-6 py-3 rounded-lg font-bold text-sm uppercase tracking-wider transition-all transform hover:scale-[1.02] active:scale-[0.98] shadow-[0_4px_20px_rgba(0,229,255,0.2)]">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"
-        class="w-5 h-5">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-      </svg>
-      Criar Novo Lote
-    </button>
+    @if (authService.usuario()?.perfil === 'operador') {
+      <button (click)="irParaNovoLote()"
+        class="flex items-center gap-2 bg-[#00E5FF] hover:bg-[#00E5FF]/90 text-black px-6 py-3 rounded-lg font-bold text-sm uppercase tracking-wider transition-all transform hover:scale-[1.02] active:scale-[0.98] shadow-[0_4px_20px_rgba(0,229,255,0.2)]">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"
+          class="w-5 h-5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+        </svg>
+        Criar Novo Lote
+      </button>
+    }
   </header>
 
   <!-- Stats Cards -->

--- a/frontend/src/app/features/lote/lote.ts
+++ b/frontend/src/app/features/lote/lote.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { LoteFeatureService } from './services/lote.service';
 import { LoteDetalhe, STATUS_CONFIG, LoteStatus } from '../../shared/models/lote.models';
 import { finalize } from 'rxjs';
+import { AuthService } from '../../core/services/auth.service';
 
 @Component({
   selector: 'app-lote',
@@ -16,6 +17,7 @@ export class Lote implements OnInit {
   private loteService = inject(LoteFeatureService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  authService = inject(AuthService);
 
   // Estados reativos (Signals)
   private lotesBase = signal<LoteDetalhe[]>([]); // Lista completa para contagens

--- a/frontend/src/app/features/lote/pages/lote-novo/lote-novo.html
+++ b/frontend/src/app/features/lote/pages/lote-novo/lote-novo.html
@@ -12,7 +12,7 @@
         </svg>
       </button>
       <div class="h-6 w-px bg-[#484847]/30"></div>
-      <span class="text-[12px] font-bold text-[#ADAAAA] uppercase tracking-[2px]">Gestão de Lotes / Criar Novo Lote</span>
+      <span class="text-[12px] font-bold text-[#ADAAAA] uppercase tracking-[2px]">Gestão de Lotes / Abrir Lote</span>
     </div>
 
     <div>
@@ -47,13 +47,19 @@
 
         <div class="flex flex-col gap-2">
           <label class="text-[10px] font-bold tracking-[1.5px] uppercase text-[#6B7280]">Produto *</label>
-          <select formControlName="produto"
-            class="w-full bg-[#0E0E0E] border border-[#484847]/80 rounded px-4 py-2.5 text-sm text-white focus:outline-none focus:border-[#00E5FF] transition-colors">
-            <option [value]="0" disabled>Selecione um produto...</option>
-            @for (prod of produtos(); track prod.id) {
-            <option [value]="prod.id">{{ prod.nome }}</option>
-            }
-          </select>
+          <div class="relative group">
+            <select formControlName="produto"
+              class="w-full bg-[#0E0E0E] border border-[#484847]/80 rounded pl-4 pr-10 py-2.5 text-sm text-white focus:outline-none focus:border-[#00E5FF] transition-colors appearance-none cursor-pointer">
+              <option [value]="0" disabled>Selecione um produto...</option>
+              @for (prod of produtos(); track prod.id) {
+              <option [value]="prod.id">{{ prod.nome }}</option>
+              }
+            </select>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" 
+              class="absolute right-4 top-1/2 -translate-y-1/2 w-4 h-4 text-[#ADAAAA] pointer-events-none group-focus-within:text-[#00E5FF] transition-colors">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+            </svg>
+          </div>
         </div>
       </div>
 
@@ -61,18 +67,40 @@
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <div class="flex flex-col gap-2">
           <label class="text-[10px] font-bold tracking-[1.5px] uppercase text-[#6B7280]">Data de Produção *</label>
-          <input type="date" formControlName="data_producao"
-            class="w-full bg-[#0E0E0E] border border-[#484847]/80 rounded px-4 py-2.5 text-sm text-white focus:outline-none focus:border-[#00E5FF] transition-colors">
+          <div class="relative date-container cursor-pointer h-[42px]" (click)="datePicker.showPicker()">
+            <!-- Campo Visual (Formato Brasileiro Forçado) -->
+            <div class="w-full h-full bg-[#0E0E0E] border border-[#484847]/80 rounded px-4 flex justify-between items-center transition-colors hover:border-[#00E5FF] group">
+              <span class="text-sm font-medium" [class.text-[#ADAAAA]]="!form.value.data_producao">
+                {{ dataFormatada() }}
+              </span>
+              
+              <!-- Ícone Único (Ciano Stylized) no Lado Direito -->
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" 
+                class="w-5 h-5 text-[#00E5FF] calendar-icon transition-all">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
+              </svg>
+            </div>
+
+            <!-- Input Nativo Escondido (Mantém a Funcionalidade e o Valor do Form) -->
+            <input #datePicker type="date" formControlName="data_producao"
+              class="absolute inset-0 opacity-0 cursor-pointer pointer-events-none">
+          </div>
         </div>
 
         <div class="flex flex-col gap-2">
           <label class="text-[10px] font-bold tracking-[1.5px] uppercase text-[#6B7280]">Turno *</label>
-          <select formControlName="turno"
-            class="w-full bg-[#0E0E0E] border border-[#484847]/80 rounded px-4 py-2.5 text-sm text-white focus:outline-none focus:border-[#00E5FF] transition-colors">
-            <option value="manha">Manhã</option>
-            <option value="tarde">Tarde</option>
-            <option value="noite">Noite</option>
-          </select>
+          <div class="relative group">
+            <select formControlName="turno"
+              class="w-full bg-[#0E0E0E] border border-[#484847]/80 rounded pl-4 pr-10 py-2.5 text-sm text-white focus:outline-none focus:border-[#00E5FF] transition-colors appearance-none cursor-pointer">
+              <option value="manha">Manhã</option>
+              <option value="tarde">Tarde</option>
+              <option value="noite">Noite</option>
+            </select>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" 
+              class="absolute right-4 top-1/2 -translate-y-1/2 w-4 h-4 text-[#ADAAAA] pointer-events-none group-focus-within:text-[#00E5FF] transition-colors">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+            </svg>
+          </div>
         </div>
       </div>
 

--- a/frontend/src/app/features/lote/pages/lote-novo/lote-novo.ts
+++ b/frontend/src/app/features/lote/pages/lote-novo/lote-novo.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, inject, OnInit, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -23,12 +23,22 @@ export class LoteNovo implements OnInit {
   salvando = signal(false);
   erro = signal<string | null>(null);
 
+
   form = this.fb.nonNullable.group({
     produto: [0, [Validators.required, Validators.min(1)]],
     data_producao: [new Date().toISOString().split('T')[0], [Validators.required]],
     turno: ['manha', [Validators.required]],
     quantidade_prod: [0, [Validators.required, Validators.min(1)]],
     observacoes: ['']
+  });
+
+  // Sinal computado para exibir a data no formato brasileiro
+  // Declarado após o form para garantir acesso seguro durante a inicialização
+  dataFormatada = computed(() => {
+    const data = this.form.controls.data_producao.value;
+    if (!data) return 'DD/MM/AAAA';
+    const [ano, mes, dia] = data.split('-');
+    return `${dia}/${mes}/${ano}`;
   });
 
   ngOnInit(): void {


### PR DESCRIPTION
- Restrita a visibilidade do botão de criar lote apenas para o perfil operador.
- Corrigida a lógica de rotas do Angular para o componente de novo lote.
- Implementado seletor de data customizado com padrão DD/MM/AAAA e ícone simplificado.
- Ajustado o alinhamento das setas e ícones nos campos de seleção (dropdowns).
- Resolvido erro de inicialização de Signals e simplificado o CSS do formulário.