### PR TITLE
fix: sincronizar contagem de insumos entre listagem e detalhes

### DIFF
--- a/backend/src/dto/insumoLote.dto.ts
+++ b/backend/src/dto/insumoLote.dto.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 
 export const insumoVinculoSchema = z.object({
   nome_insumo: z.string().min(2, "O nome deve ter pelo menos 2 caracteres.").max(100, "O nome do insumo deve ter no máximo 100 caracteres."),
-  codigo_insumo: z.string().min(1, "Código do insumo não pode ser vazio.").optional(),
-  lote_insumo: z.string().min(1, "Informe o lote do fornecedor para rastreabilidade.").optional(),
+  codigo_insumo: z.preprocess((val) => val === "" ? undefined : val, z.string().min(1, "Código do insumo não pode ser vazio.").optional()),
+  lote_insumo: z.preprocess((val) => val === "" ? undefined : val, z.string().min(1, "Informe o lote do fornecedor para rastreabilidade.").optional()),
   quantidade: z.coerce.number().positive("A quantidade deve ser maior que zero."),
   unidade: z.string().min(1, "Unidade de medida inválida. Use: kg, g, L, mL, m, cm, mm, unid, etc."),
 });

--- a/backend/src/services/insumoLote.service.ts
+++ b/backend/src/services/insumoLote.service.ts
@@ -45,9 +45,9 @@ export class InsumoLoteService {
         nome_insumo: insumo.nome_insumo,
         codigo_insumo: insumo.codigo_insumo,
         lote_insumo: insumo.lote_insumo,
-        quantidade: insumo.quantidade,
+        quantidade: Number(insumo.quantidade),
         unidade: insumo.unidade,
-        lote: { id: lote.id },
+        lote: lote, // Usando a entidade completa em vez de apenas o ID
       } as DeepPartial<InsumoLote>)
     );
 

--- a/backend/src/services/lote.service.ts
+++ b/backend/src/services/lote.service.ts
@@ -159,7 +159,7 @@ export class LoteService {
     return await this.loteRepo.find({
       where,
       order: { aberto_em: "DESC" },
-      relations: ['operador', 'produto']
+      relations: ['operador', 'produto', 'insumos']
     });
   }
 

--- a/frontend/src/app/features/lote/pages/lote-detail/lote-detail.html
+++ b/frontend/src/app/features/lote/pages/lote-detail/lote-detail.html
@@ -145,10 +145,17 @@
   <!-- ── Insumos Vinculados ── -->
   <div class="bg-[#131313] border border-[#484847]/30 rounded-md p-6">
     <div class="flex items-center justify-between mb-4">
-      <span
-        class="text-[11px] font-bold text-[#00E5FF] bg-[rgba(0,229,255,0.1)] border border-[#00E5FF] px-2.5 py-1 rounded">
-        {{ (lote()!.insumos?.length || 0) }} {{ (lote()!.insumos?.length === 1 ? 'item' : 'itens') }}
-      </span>
+      <div class="flex items-center gap-3">
+        <span
+          class="text-[11px] font-bold text-[#00E5FF] bg-[rgba(0,229,255,0.1)] border border-[#00E5FF] px-2.5 py-1 rounded">
+          {{ totalInsumos() }} {{ (totalInsumos() === 1 ? 'item' : 'itens') }}
+        </span>
+        @if (novosInsumos().length > 0) {
+          <span class="text-[10px] text-[#DFFF00] font-medium italic animate-pulse">
+            + {{ novosInsumos().length }} aguardando salvamento
+          </span>
+        }
+      </div>
     </div>
 
     @if (!lote()?.insumos || (lote()?.insumos?.length === 0)) {

--- a/frontend/src/app/features/lote/pages/lote-detail/lote-detail.ts
+++ b/frontend/src/app/features/lote/pages/lote-detail/lote-detail.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -42,9 +42,15 @@ export class LoteDetail implements OnInit {
   // Controle de edição para OPERADORES
   processando = signal(false);
   insumosMaster = signal<InsumoMaster[]>([]);
-  
+
   // Lista temporária de insumos que serão enviados à API juntos (se preferir múltiplo) ou um a um
   novosInsumos = signal<{ nome_insumo: string, codigo_insumo: string, lote_insumo: string, quantidade: number, unidade: string }[]>([]);
+
+  totalInsumos = computed(() => {
+    const salvos = this.lote()?.insumos?.length || 0;
+    const pendentes = this.novosInsumos().length;
+    return salvos + pendentes;
+  });
 
   formInsumo = this.fb.nonNullable.group({
     nome_insumo: ['', Validators.required],
@@ -110,7 +116,7 @@ export class LoteDetail implements OnInit {
   onInsumoSelected(event: Event) {
     const id = Number((event.target as HTMLSelectElement).value);
     const insumo = this.insumosMaster().find(i => i.id === id);
-    
+
     if (insumo) {
       this.formInsumo.patchValue({
         nome_insumo: insumo.nome,


### PR DESCRIPTION
- Adicionado carregamento da relação 'insumos' na listagem principal do backend para exibir a contagem correta nos cards.
- Implementado sinal computado 'totalInsumos' para atualizar o contador da interface instantaneamente ao adicionar itens.
- Refatorada a lógica de persistência no backend para usar associação de entidade completa, garantindo maior integridade no TypeORM.
- Adicionado indicador visual de itens pendentes de salvamento para melhor UX do operador.
- Corrigida a importação faltante do 'computed' no Angular que impedia a renderização da página.