### PR TITLE
feat: adicionar suporte ao campo 'criadoPor' em produtos e usuários

### DIFF
--- a/backend/src/entities/Produto.ts
+++ b/backend/src/entities/Produto.ts
@@ -12,6 +12,7 @@ import {
 
 import type { ReceitaItem } from "./ReceitaItem.js";
 import type { Lote } from "./Lote.js";
+import type { Usuario } from "./Usuario.js";
 
 /**
  * Define um produto acabado e suas regras de qualidade.
@@ -47,6 +48,10 @@ export class Produto {
 
   @UpdateDateColumn({ type: "timestamptz" })
   atualizado_em!: Date;
+
+  @ManyToOne("Usuario")
+  @JoinColumn({ name: "criado_por_id" })
+  criadoPor!: Relation<Usuario>;
 
   @OneToMany("ReceitaItem", "produto", { cascade: true })
   receita!: Relation<ReceitaItem>[];

--- a/backend/src/entities/Usuario.ts
+++ b/backend/src/entities/Usuario.ts
@@ -4,6 +4,8 @@ import {
   Column,
   CreateDateColumn,
   OneToMany,
+  ManyToOne,
+  JoinColumn,
   type Relation,
 } from "typeorm";
 
@@ -44,6 +46,10 @@ export class Usuario {
 
   @CreateDateColumn({ type: "timestamptz" })
   criado_em!: Date;
+
+  @ManyToOne("Usuario")
+  @JoinColumn({ name: "criado_por_id" })
+  criadoPor?: Relation<Usuario>;
 
   @OneToMany("Lote", "operador")
   lotes!: Relation<Lote>[];

--- a/backend/src/services/produto.service.ts
+++ b/backend/src/services/produto.service.ts
@@ -46,6 +46,10 @@ export class ProdutoService {
   criar = async (dto: CriarProdutoDTO, requisitante: Requisitante): Promise<Produto> => {
     verificaPermissao(requisitante, [PerfilUsuario.GESTOR]);
 
+    const userRepo = AppDataSource.getRepository("Usuario");
+    const criador = await userRepo.findOneBy({ id: requisitante.id });
+    if (!criador) throw new AppError("Criador não encontrado.", 404);
+
     const skuBase = this.gerarSku(dto.nome);
     const skuUnico = await this.garantirSkuUnico(skuBase);
 
@@ -57,6 +61,7 @@ export class ProdutoService {
         linha_padrao: dto.linha_padrao,
         percentual_ressalva: dto.percentual_ressalva,
         ativo: dto.ativo,
+        criadoPor: criador as any,
       });
 
       const produtoSalvo = await manager.save(produto);
@@ -100,7 +105,7 @@ export class ProdutoService {
     ]);
 
     return this.produtoRepo.find({
-      relations: ["receita", "receita.materiaPrima", "lotes"],
+      relations: ["receita", "receita.materiaPrima", "lotes", "criadoPor"],
       order: { nome: "ASC" },
     });
   };
@@ -114,7 +119,7 @@ export class ProdutoService {
 
     const produto = await this.produtoRepo.findOne({
       where: { id },
-      relations: ["receita", "receita.materiaPrima"],
+      relations: ["receita", "receita.materiaPrima", "criadoPor"],
     });
 
     if (!produto) throw new AppError("Produto não encontrado.", 404);

--- a/backend/src/services/rastreabilidade.service.ts
+++ b/backend/src/services/rastreabilidade.service.ts
@@ -28,14 +28,14 @@ export class RastreabilidadeService {
       this.loteRepo
         .createQueryBuilder("l")
         .leftJoinAndSelect("l.produto", "p")
-        .where("l.numero_lote LIKE :termo", { termo })
+        .where("l.numero_lote ILIKE :termo", { termo })
         .limit(6)
         .getMany(),
       this.insumoRepo
         .createQueryBuilder("ie")
         .leftJoinAndSelect("ie.materiaPrima", "mp")
-        .where("ie.numero_lote_interno LIKE :termo", { termo })
-        .orWhere("ie.numero_lote_fornecedor LIKE :termo", { termo })
+        .where("ie.numero_lote_interno ILIKE :termo", { termo })
+        .orWhere("ie.numero_lote_fornecedor ILIKE :termo", { termo })
         .limit(6)
         .getMany(),
     ]);
@@ -60,18 +60,18 @@ export class RastreabilidadeService {
 
   /** Consulta por número de lote de produção */
   private consultarPorLote = async (termo: string) => {
-    const lote = await this.loteRepo.findOne({
-      where: { numero_lote: termo },
-      relations: [
-        "produto",
-        "operador",
-        "consumos",
-        "consumos.insumoEstoque",
-        "consumos.insumoEstoque.materiaPrima",
-        "inspecao",
-        "inspecao.inspetor",
-      ],
-    });
+    const lote = await this.loteRepo
+      .createQueryBuilder("l")
+      .leftJoinAndSelect("l.produto", "produto")
+      .leftJoinAndSelect("l.operador", "operador")
+      .leftJoinAndSelect("l.consumos", "consumos")
+      .leftJoinAndSelect("consumos.insumoEstoque", "insumoEstoque")
+      .leftJoinAndSelect("insumoEstoque.materiaPrima", "materiaPrima")
+      .leftJoinAndSelect("insumoEstoque.operador", "operadorInsumo")
+      .leftJoinAndSelect("l.inspecao", "inspecao")
+      .leftJoinAndSelect("inspecao.inspetor", "inspetor")
+      .where("l.numero_lote ILIKE :termo", { termo })
+      .getOne();
 
     if (!lote) throw new AppError(`Nenhum lote encontrado com o número '${termo}'.`, 404);
     return lote;
@@ -83,11 +83,12 @@ export class RastreabilidadeService {
       .createQueryBuilder("ci")
       .leftJoinAndSelect("ci.insumoEstoque", "ie")
       .leftJoinAndSelect("ie.materiaPrima", "mp")
+      .leftJoinAndSelect("ie.operador", "opInsumo")
       .leftJoinAndSelect("ci.lote", "lote")
       .leftJoinAndSelect("lote.produto", "produto")
       .leftJoinAndSelect("lote.operador", "operador")
-      .where("ie.numero_lote_interno = :termo", { termo })
-      .orWhere("ie.numero_lote_fornecedor = :termo", { termo })
+      .where("ie.numero_lote_interno ILIKE :termo", { termo })
+      .orWhere("ie.numero_lote_fornecedor ILIKE :termo", { termo })
       .getMany();
 
     if (consumos.length === 0) {
@@ -99,6 +100,7 @@ export class RastreabilidadeService {
       produto: string;
       data_producao: Date;
       status: string;
+      operador_nome: string;
       insumos_correspondentes: { nome: string; lote_interno: string; quantidade: number }[];
     }>();
 
@@ -119,6 +121,7 @@ export class RastreabilidadeService {
           produto: lote.produto.nome,
           data_producao: lote.data_producao,
           status: lote.status,
+          operador_nome: lote.operador?.nome ?? "—",
           insumos_correspondentes: [insumoInfo],
         });
       }
@@ -130,7 +133,7 @@ export class RastreabilidadeService {
   consultar = async (termo: string, requisitante: Requisitante) => {
     verificaPermissao(requisitante, [PerfilUsuario.GESTOR, PerfilUsuario.INSPETOR, PerfilUsuario.OPERADOR]);
 
-    const ehLoteProduto = termo.startsWith("LOT-");
+    const ehLoteProduto = termo.toUpperCase().startsWith("LOT-");
 
     if (ehLoteProduto) {
       return {

--- a/backend/src/services/usuario.service.ts
+++ b/backend/src/services/usuario.service.ts
@@ -22,13 +22,19 @@ export class UsuarioService {
 
   findAll = async (requisitante: Requisitante): Promise<UsuarioSemSenha[]> => {
     verificaPermissao(requisitante, [PerfilUsuario.GESTOR]);
-    const usuarios = await this.userRepo.find({ order: { nome: 'ASC' } });
+    const usuarios = await this.userRepo.find({ 
+      relations: ['criadoPor'],
+      order: { nome: 'ASC' } 
+    });
 
     return usuarios.map(omitSenha);
   }
 
   findById = async (id: number, requisitante: Requisitante): Promise<UsuarioSemSenha> => {
-    const usuario = await this.userRepo.findOne({ where: { id } });
+    const usuario = await this.userRepo.findOne({ 
+      where: { id },
+      relations: ['criadoPor']
+    });
     if (!usuario) throw new AppError('Usuário não encontrado', 404);
 
     verificaPermissao(requisitante, [PerfilUsuario.GESTOR], id);
@@ -79,10 +85,17 @@ export class UsuarioService {
     const existe = await this.userRepo.findOne({ where: { email: dto.email } });
     if (existe) throw new AppError(`E-mail '${dto.email}' já está em uso`, 409);
 
+    const criador = await this.userRepo.findOneBy({ id: requisitante.id });
+    if (!criador) throw new AppError('Criador não encontrado', 404);
+
     const senha_hash = await bcrypt.hash(dto.senha, SALT_ROUNDS);
 
     const { senha: _, ...dadosSemSenha } = dto;
-    const usuario = this.userRepo.create({ ...dadosSemSenha, senha_hash });
+    const usuario = this.userRepo.create({ 
+      ...dadosSemSenha, 
+      senha_hash,
+      criadoPor: criador 
+    });
 
     const salvo = await this.userRepo.save(usuario);
 

--- a/frontend/src/app/core/services/usuario.service.ts
+++ b/frontend/src/app/core/services/usuario.service.ts
@@ -8,6 +8,7 @@ export interface UsuarioPerfil {
   perfil: string;
   ativo: boolean;
   criado_em: string;
+  criadoPor?: { nome: string };
 }
 
 export interface UsuarioStats {

--- a/frontend/src/app/features/cadastro-usuarios/cadastro-usuarios.html
+++ b/frontend/src/app/features/cadastro-usuarios/cadastro-usuarios.html
@@ -195,7 +195,8 @@
                   <th class="py-2 pr-2">Nome</th>
                   <th class="py-2 pr-2">E-mail</th>
                   <th class="py-2 pr-2">Perfil</th>
-                  <th class="py-2">Status</th>
+                  <th class="py-2 pr-2">Status</th>
+                  <th class="py-2">Cadastrado Por</th>
                 </tr>
               </thead>
               <tbody>
@@ -204,9 +205,10 @@
                     <td class="py-2 pr-2 text-[#ADAAAA]">{{ usuario.nome }}</td>
                     <td class="py-2 pr-2 text-[#ADAAAA]">{{ usuario.email }}</td>
                     <td class="py-2 pr-2 text-white capitalize">{{ usuario.perfil }}</td>
-                    <td class="py-2" [class.text-[#81ECFF]]="usuario.ativo" [class.text-[#fca5a5]]="!usuario.ativo">
+                    <td class="py-2 pr-2" [class.text-[#81ECFF]]="usuario.ativo" [class.text-[#fca5a5]]="!usuario.ativo">
                       {{ usuario.ativo ? 'Ativo' : 'Inativo' }}
                     </td>
+                    <td class="py-2 text-[#ADAAAA]">{{ usuario.criadoPor?.nome || 'Sistema' }}</td>
                   </tr>
                 }
               </tbody>

--- a/frontend/src/app/features/cadastro-usuarios/cadastro-usuarios.ts
+++ b/frontend/src/app/features/cadastro-usuarios/cadastro-usuarios.ts
@@ -48,8 +48,8 @@ export class CadastroUsuarios {
   cadastrados = signal<UsuarioPerfil[]>([]);
 
   filtroTermo = signal('');
-  filtroPerfil = signal<'operador' | 'inspetor' | 'gestor'>('operador');
-  filtroStatus = signal<'ativos' | 'inativos'>('ativos');
+  filtroPerfil = signal<'todos' | 'operador' | 'inspetor' | 'gestor'>('todos');
+  filtroStatus = signal<'todos' | 'ativos' | 'inativos'>('todos');
 
   cadastradosFiltrados = computed(() => {
     const termo = this.filtroTermo().trim().toLowerCase();
@@ -62,9 +62,14 @@ export class CadastroUsuarios {
         u.nome.toLowerCase().includes(termo) ||
         u.email.toLowerCase().includes(termo);
 
-      const perfilOk = u.perfil === perfil;
+      const perfilOk = perfil === 'todos' ? true : u.perfil === perfil;
 
-      const statusOk = status === 'ativos' ? u.ativo : !u.ativo;
+      const statusOk =
+        status === 'todos'
+          ? true
+          : status === 'ativos'
+            ? u.ativo
+            : !u.ativo;
 
       return termoOk && perfilOk && statusOk;
     });
@@ -77,12 +82,14 @@ export class CadastroUsuarios {
   ];
 
   filtroPerfilOptions: SelectOption[] = [
+    { value: 'todos', label: 'Todos' },
     { value: 'operador', label: 'Operador' },
     { value: 'inspetor', label: 'Inspetor' },
     { value: 'gestor', label: 'Gestor' },
   ];
 
   filtroStatusOptions: SelectOption[] = [
+    { value: 'todos', label: 'Todos' },
     { value: 'ativos', label: 'Ativos' },
     { value: 'inativos', label: 'Inativos' },
   ];
@@ -164,14 +171,14 @@ export class CadastroUsuarios {
   }
 
   setFiltroPerfil(value: string): void {
-    const allowed = new Set(['operador', 'inspetor', 'gestor']);
+    const allowed = new Set(['todos', 'operador', 'inspetor', 'gestor']);
     if (allowed.has(value)) {
       this.filtroPerfil.set(value as any);
     }
   }
 
   setFiltroStatus(value: string): void {
-    const allowed = new Set(['ativos', 'inativos']);
+    const allowed = new Set(['todos', 'ativos', 'inativos']);
     if (allowed.has(value)) {
       this.filtroStatus.set(value as any);
     }

--- a/frontend/src/app/features/insumos/components/estoque-card/estoque-card.component.html
+++ b/frontend/src/app/features/insumos/components/estoque-card/estoque-card.component.html
@@ -60,7 +60,11 @@
     </div>
     <div class="flex justify-between items-center border-t border-[#484847]/10 pt-2">
       <span class="text-[9px] font-bold text-[#6B7280] uppercase tracking-wider">Recebimento</span>
-      <span class="text-[10px] text-[#6B7280]">{{ formatarData(item.recebido_em) }}</span>
+      <span class="text-[10px] text-[#ADAAAA]">{{ formatarData(item.recebido_em) }}</span>
+    </div>
+    <div class="flex justify-between items-center border-t border-[#484847]/10 pt-2">
+      <span class="text-[9px] font-bold text-[#6B7280] uppercase tracking-wider">Operador</span>
+      <span class="text-[10px] text-white">{{ item.operador?.nome || '—' }}</span>
     </div>
   </div>
 </div>

--- a/frontend/src/app/features/produtos/components/produto-card/produto-card.html
+++ b/frontend/src/app/features/produtos/components/produto-card/produto-card.html
@@ -52,6 +52,10 @@
         <span class="text-[10px] text-[#484847]">lotes</span>
       </div>
     </div>
+    <div class="flex flex-col items-center">
+      <span class="text-[9px] font-bold text-[#6B7280] uppercase tracking-wider">Cadastrado por</span>
+      <span class="text-[10px] text-[#ADAAAA]">{{ prod.criadoPor?.nome || 'Sistema' }}</span>
+    </div>
     <div class="flex flex-col items-end">
       <span class="text-[9px] font-bold text-[#6B7280] uppercase tracking-wider">Atualização</span>
       <span class="text-xs text-[#ADAAAA]">{{ formatarData(prod.atualizado_em) }}</span>

--- a/frontend/src/app/features/rastreabilidade/components/rastreabilidade-arvore-lote/rastreabilidade-arvore-lote.component.html
+++ b/frontend/src/app/features/rastreabilidade/components/rastreabilidade-arvore-lote/rastreabilidade-arvore-lote.component.html
@@ -85,6 +85,10 @@
           <span class="text-[9px] text-[#6B7280] uppercase font-bold tracking-wider">Fornecedor</span>
           <span class="text-[11px] text-[#ADAAAA]">{{ consumo.insumoEstoque.fornecedor }}</span>
         </div>
+        <div class="flex justify-between items-center">
+          <span class="text-[9px] text-[#6B7280] uppercase font-bold tracking-wider">Registrado por</span>
+          <span class="text-[11px] text-white">{{ consumo.insumoEstoque.operador?.nome || '—' }}</span>
+        </div>
         <div class="flex justify-between items-center pt-2 border-t border-[#484847]/20">
           <span class="text-[9px] text-[#6B7280] uppercase font-bold tracking-wider">Qtd. Consumida</span>
           <span class="text-sm font-bold text-white">{{ consumo.quantidade_consumida }} <span class="text-[#6B7280] text-[9px]">{{ consumo.insumoEstoque.materiaPrima.unidade_medida }}</span></span>

--- a/frontend/src/app/features/rastreabilidade/components/rastreabilidade-arvore-recall/rastreabilidade-arvore-recall.component.html
+++ b/frontend/src/app/features/rastreabilidade/components/rastreabilidade-arvore-recall/rastreabilidade-arvore-recall.component.html
@@ -50,6 +50,10 @@
           <span class="text-[9px] text-[#6B7280] uppercase font-bold tracking-wider">Data Produção</span>
           <span class="text-[11px] text-[#ADAAAA]">{{ formatarData(lote.data_producao) }}</span>
         </div>
+        <div class="flex justify-between items-center">
+          <span class="text-[9px] text-[#6B7280] uppercase font-bold tracking-wider">Operador</span>
+          <span class="text-[11px] text-white">{{ lote.operador_nome }}</span>
+        </div>
         @for (ins of lote.insumos_correspondentes; track ins.lote_interno) {
         <div class="flex justify-between items-center pt-2 border-t border-red-500/10">
           <span class="text-[9px] text-red-400/70 uppercase font-bold tracking-wider">Qtd. Usada</span>

--- a/frontend/src/app/features/rastreabilidade/rastreabilidade.ts
+++ b/frontend/src/app/features/rastreabilidade/rastreabilidade.ts
@@ -33,6 +33,7 @@ export interface ResultadoLote {
         numero_lote_interno: string;
         numero_lote_fornecedor: string;
         fornecedor: string;
+        operador?: { nome: string };
         materiaPrima: { nome: string; sku_interno: string; unidade_medida: string };
       };
     }[];
@@ -52,6 +53,7 @@ export interface ResultadoInsumo {
     produto: string;
     data_producao: string;
     status: LoteStatus;
+    operador_nome: string;
     insumos_correspondentes: { nome: string; lote_interno: string; quantidade: number }[];
   }[];
 }

--- a/frontend/src/app/shared/models/lote.models.ts
+++ b/frontend/src/app/shared/models/lote.models.ts
@@ -37,6 +37,9 @@ export interface Produto {
   ativo: boolean;
   receita: ReceitaItem[];
   lotes?: any[];
+  criadoPor?: { nome: string };
+  criado_em: string;
+  atualizado_em: string;
 }
 
 export interface Operador {
@@ -55,6 +58,7 @@ export interface InsumoEstoque {
   turno: string;
   data_validade: string | null;
   recebido_em: string;
+  operador?: Operador;
 }
 
 export interface ConsumoInsumo {


### PR DESCRIPTION
- Implementada a relação 'criadoPor' nas entidades Produto e Usuario para rastrear quem criou cada registro.
- Atualizados os serviços ProdutoService e UsuarioService para incluir a lógica de atribuição do criador durante a criação de novos registros.
- Modificadas as consultas para incluir a relação 'criadoPor' nas buscas de usuários e produtos.
- Atualizadas as interfaces e componentes do frontend para exibir o nome do criador onde aplicável.