### PR TITLE
feat: últimos lotes tornados interativos e clicáveis

### DIFF
--- a/frontend/src/app/features/dashboard/dashboard.html
+++ b/frontend/src/app/features/dashboard/dashboard.html
@@ -139,7 +139,7 @@
         </thead>
         <tbody>
           @for (lote of ultimosLotes(); track lote.id) {
-          <tr class="flex w-full border-b border-[#201F1F]/30 hover:bg-[#FFFFFF]/5 transition-all">
+          <tr (click)="irParaDetalhe(lote.id)" class="flex w-full border-b border-[#201F1F]/30 hover:bg-[#FFFFFF]/5 transition-all cursor-pointer">
             <td class="text-[14px] leading-[20px] tracking-[0px] px-6 py-4 text-left w-[20.62%] text-[#FFFFFF]">
               {{ lote.numero_lote }}
             </td>
@@ -173,6 +173,7 @@
     <div class="flex flex-col lg:hidden">
       @for (lote of ultimosLotes(); track lote.id) {
       <div
+        (click)="irParaDetalhe(lote.id)"
         class="flex justify-between items-center px-4 py-6 border-b border-[#201F1F]/50 hover:bg-[#FFFFFF]/5 transition-all cursor-pointer">
         <div class="flex flex-col gap-1 w-1/2">
           <h4 class="font-bold text-[14px] leading-[18px] text-white overflow-hidden text-ellipsis whitespace-nowrap">


### PR DESCRIPTION
- Adicionado evento de clique nas linhas da tabela de "Últimos 10 Lotes" e na lista mobile.
- Implementado redirecionamento automático para a tela de detalhes do lote ao clicar em um item.
- Adicionada classe visual cursor-pointer para indicar interatividade ao usuário.