### PR TITLE
feat: paginação server-side, métricas globais e otimização de cards

### DIFF
--- a/backend/src/controllers/lote.controller.ts
+++ b/backend/src/controllers/lote.controller.ts
@@ -13,7 +13,14 @@ export const criar = async (req: Request, res: Response, next: NextFunction) => 
 
 export const listar = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const resultado = await service.listar(getRequisitante(req));
+    const resultado = await service.listar(req.query as any, getRequisitante(req));
+    res.json(resultado);
+  } catch (e) { next(e); }
+};
+
+export const getContagem = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const resultado = await service.getContagemPorStatus(getRequisitante(req));
     res.json(resultado);
   } catch (e) { next(e); }
 };

--- a/backend/src/dto/lote.dto.ts
+++ b/backend/src/dto/lote.dto.ts
@@ -1,4 +1,11 @@
 import { z } from "zod";
+import { PaginacaoQueryDto } from "./paginacao.dto.js";
+
+export const ListLotesQueryDto = PaginacaoQueryDto.extend({
+  status: z.string().optional(),
+});
+
+export type ListLotesQueryDto = z.infer<typeof ListLotesQueryDto>;
 
 const turnoSchema = z.enum(["manha", "tarde", "noite"], {
   message: "Turno inválido. Valores aceitos: manha, tarde, noite.",

--- a/backend/src/routes/lote.routes.ts
+++ b/backend/src/routes/lote.routes.ts
@@ -1,16 +1,18 @@
 import { Router } from "express";
 import * as ctrl from "../controllers/lote.controller.js";
 import { validateBody } from "../middlewares/validateBody.js";
-import { criarLoteSchema } from "../dto/lote.dto.js";
+import { validateQuery } from "../middlewares/validateQuery.js";
+import { criarLoteSchema, transicaoStatusSchema, ListLotesQueryDto } from "../dto/lote.dto.js";
 import { roleGuard } from "../middlewares/roleGuard.js";
 import { PerfilUsuario } from "../entities/Usuario.js";
 
 const router = Router();
 
-router.get("/", ctrl.listar);
+router.get("/", validateQuery(ListLotesQueryDto), ctrl.listar);
 router.get("/config", ctrl.getConfig);
+router.get("/stats/contagem", ctrl.getContagem);
 router.get("/:id", ctrl.buscarPorId);
-// Apenas OPERADOR (e GESTOR, que sempre passa) podem abrir lotes
+// Apenas OPERADOR pode abrir lotes (regra de negócio #2)
 router.post("/", roleGuard(PerfilUsuario.OPERADOR), validateBody(criarLoteSchema), ctrl.criar);
 
 export default router;

--- a/backend/src/services/lote.service.ts
+++ b/backend/src/services/lote.service.ts
@@ -10,6 +10,7 @@ import { verificaPermissao, type Requisitante } from "../utils/auth.utils.js";
 import type { CriarLoteDTO } from "../dto/lote.dto.js";
 import { NotificacaoService } from "./notificacao.service.js";
 import { TipoNotificacao } from "../entities/Notificacao.js";
+import { PaginacaoQueryDto, formatarRespostaPaginada, type RespostaPaginada } from "../dto/paginacao.dto.js";
 
 export class LoteService {
   private loteRepo: Repository<Lote>;
@@ -163,17 +164,66 @@ export class LoteService {
     });
   };
 
-  listar = async (requisitante: Requisitante): Promise<Lote[]> => {
+  listar = async (query: PaginacaoQueryDto & { status?: string }, requisitante: Requisitante): Promise<RespostaPaginada<Lote>> => {
     verificaPermissao(requisitante, [
       PerfilUsuario.OPERADOR,
       PerfilUsuario.INSPETOR,
       PerfilUsuario.GESTOR,
     ]);
 
-    return this.loteRepo.find({
-      relations: ["operador", "produto", "consumos", "consumos.insumoEstoque"],
-      order: { aberto_em: "DESC" },
+    const { pagina, limite, busca, status } = query;
+    const skip = (pagina - 1) * limite;
+
+    const queryBuilder = this.loteRepo.createQueryBuilder("lote")
+      .leftJoinAndSelect("lote.produto", "produto")
+      .leftJoinAndSelect("lote.operador", "operador")
+      .leftJoinAndSelect("lote.inspecao", "inspecao")
+      .leftJoinAndSelect("lote.consumos", "consumos")
+      .skip(skip)
+      .take(limite)
+      .orderBy("lote.aberto_em", "DESC");
+
+    if (busca) {
+      queryBuilder.andWhere("(lote.numero_lote ILIKE :busca OR produto.nome ILIKE :busca)", { busca: `%${busca}%` });
+    }
+
+    if (status && status !== 'todos') {
+      queryBuilder.andWhere("lote.status = :status", { status });
+    }
+
+    const [lotes, total] = await queryBuilder.getManyAndCount();
+
+    return formatarRespostaPaginada([lotes, total], query);
+  };
+
+  getContagemPorStatus = async (requisitante: Requisitante): Promise<Record<string, number>> => {
+    verificaPermissao(requisitante, [PerfilUsuario.GESTOR, PerfilUsuario.OPERADOR, PerfilUsuario.INSPETOR]);
+
+    const counts = await this.loteRepo
+      .createQueryBuilder("lote")
+      .select("lote.status", "status")
+      .addSelect("COUNT(*)", "count")
+      .groupBy("lote.status")
+      .getRawMany<{ status: string; count: string }>();
+
+    const result: Record<string, number> = {
+      todos: 0,
+      em_producao: 0,
+      aguardando_inspecao: 0,
+      aprovado: 0,
+      aprovado_restricao: 0,
+      reprovado: 0,
+    };
+
+    let total = 0;
+    counts.forEach((c) => {
+      const count = Number(c.count);
+      result[c.status] = count;
+      total += count;
     });
+    result.todos = total;
+
+    return result;
   };
 
   buscarPorId = async (id: number, requisitante: Requisitante): Promise<Lote> => {

--- a/frontend/src/app/features/lote/lote.html
+++ b/frontend/src/app/features/lote/lote.html
@@ -83,13 +83,23 @@
 
   <!-- Cards List -->
   @else {
-  <div class="grid grid-cols-1 md:grid-cols-2 2xl:grid-cols-3 gap-6">
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 
-    @for (lote of lotes(); track lote.id; let i = $index) {
-    <app-lote-card class="animate-scale-in stagger-item" [lote]="lote" (cardClick)="irParaDetalhe($event)">
+    @for (lote of lotes(); track lote.id) {
+    <app-lote-card 
+      class="animate-fade-in" 
+      [lote]="lote" 
+      [duracaoProducaoMs]="duracaoMs()"
+      (cardClick)="irParaDetalhe($event)">
     </app-lote-card>
     }
 
   </div>
+
+  @if (paginationMeta(); as meta) {
+    @if (meta.totalPaginas > 1) {
+      <app-pagination [meta]="meta" (pageChange)="onPageChange($event)"></app-pagination>
+    }
+  }
   }
 </div>

--- a/frontend/src/app/features/lote/lote.ts
+++ b/frontend/src/app/features/lote/lote.ts
@@ -10,6 +10,7 @@ import { LoteCardComponent } from '../../shared/components/lote-card/lote-card';
 import { FilterTabsComponent, FilterTab } from '../../shared/components/filter-tabs/filter-tabs';
 import { PageHeaderComponent } from '../../shared/components/page-header/page-header';
 import { ConfiguracoesService } from '../../core/services/configuracoes.service';
+import { PaginationComponent, PaginationMeta } from '../../shared/components/pagination/pagination';
 
 /** Fallback caso o backend não responda — 2 minutos como padrão de demo */
 const FALLBACK_DURACAO_MS = 2 * 60 * 1000;
@@ -17,7 +18,7 @@ const FALLBACK_DURACAO_MS = 2 * 60 * 1000;
 @Component({
   selector: 'app-lote',
   standalone: true,
-  imports: [CommonModule, StatCardComponent, LoteCardComponent, FilterTabsComponent, PageHeaderComponent, DecimalPipe],
+  imports: [CommonModule, StatCardComponent, LoteCardComponent, FilterTabsComponent, PageHeaderComponent, DecimalPipe, PaginationComponent],
   templateUrl: './lote.html',
   styleUrl: './lote.css',
 })
@@ -40,10 +41,12 @@ export class Lote implements OnInit, OnDestroy {
   ];
 
   // Estados reativos (Signals)
-  private lotesBase = signal<LoteDetalhe[]>([]); // Lista completa para contagens
+  lotes = signal<LoteDetalhe[]>([]);
+  paginationMeta = signal<PaginationMeta | null>(null);
   carregando = signal<boolean>(false);
   erro = signal<string | null>(null);
   filtroAtivo = signal<string>('todos');
+  currentPage = signal<number>(1);
 
   /**
    * Signal que incrementa a cada segundo.
@@ -52,18 +55,9 @@ export class Lote implements OnInit, OnDestroy {
    */
   private tick = signal<number>(Date.now());
 
-  // Sinal computado para exibir apenas os lotes que batem com o filtro selecionado
-  lotes = computed(() => {
-    const lista = this.lotesBase();
-    const filtro = this.filtroAtivo();
-
-    if (filtro === 'todos') return lista;
-    return lista.filter(l => l.status === filtro);
-  });
-
   // Estatísticas computadas
   /** Duração de produção em ms — carregada do backend, com fallback */
-  private duracaoMs = signal<number>(FALLBACK_DURACAO_MS);
+  protected duracaoMs = signal<number>(FALLBACK_DURACAO_MS);
 
   producaoTotalLabel = computed(() => {
     const p = this.configuracoesService.settings().lote.producaoTotalPeriodo;
@@ -77,60 +71,39 @@ export class Lote implements OnInit, OnDestroy {
   });
 
   producaoTotalAcumulada = computed(() => {
-    const period = this.configuracoesService.settings().lote.producaoTotalPeriodo;
-    const now = new Date();
-    let filteredLotes = this.lotesBase();
-
-    if (period === 'mes') {
-      filteredLotes = filteredLotes.filter(l => {
-        const d = new Date(l.aberto_em);
-        return d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear();
-      });
-    } else if (period === 'semana') {
-      // Simplificação de semana (últimos 7 dias)
-      const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-      filteredLotes = filteredLotes.filter(l => new Date(l.aberto_em) >= oneWeekAgo);
-    } else if (period === 'dia') {
-      filteredLotes = filteredLotes.filter(l => {
-        const d = new Date(l.aberto_em);
-        return d.getDate() === now.getDate() && d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear();
-      });
-    }
-
-    return filteredLotes.reduce((acc, curr) => acc + (curr.quantidade_planejada || 0), 0);
+    // IMPORTANTE: Como a lista é paginada, a métrica deve usar o totalItens do meta global
+    return this.paginationMeta()?.totalItens || 0;
   });
 
   statsCargaSistema = computed(() => {
-    const baseValue = this.configuracoesService.settings().lote.atividadeTempoRealBase || 1000;
-    const emProducao = this.lotesBase().filter(l => l.status === 'em_producao').length;
-    // Cálculo: (emProducao / baseValue) * 100
+    const baseValue = this.configuracoesService.settings().lote.atividadeTempoRealBase || 5;
+    // IMPORTANTE: Usa a contagem global do servidor para a métrica, não apenas a página atual
+    const emProducao = this.contagemPorStatus()['em_producao'] || 0;
     const val = (emProducao / baseValue) * 100;
     return parseFloat(val.toFixed(1));
   });
 
-  contagemPorStatus = computed(() => {
-    const counts: Record<LoteStatus | 'todos', number> = {
-      todos: this.lotesBase().length,
-      em_producao: 0,
-      aguardando_inspecao: 0,
-      aprovado: 0,
-      reprovado: 0,
-      aprovado_restricao: 0
-    };
-
-    this.lotesBase().forEach(l => {
-      if (counts[l.status] !== undefined) {
-        counts[l.status]++;
-      }
-    });
-
-    return counts;
+  contagemPorStatus = signal<Record<string, number>>({
+    todos: 0,
+    em_producao: 0,
+    aguardando_inspecao: 0,
+    aprovado: 0,
+    reprovado: 0,
+    aprovado_restricao: 0
   });
 
   ngOnInit(): void {
+    // Escuta mudanças na URL para atualizar os sinais e carregar os dados
     this.route.queryParams.subscribe(params => {
-      const busca = params['busca'];
+      const busca = params['busca'] || '';
+      const status = params['status'] || 'todos';
+      const pagina = Number(params['pagina']) || 1;
+      
+      this.filtroAtivo.set(status);
+      this.currentPage.set(pagina);
+      
       this.carregarLotes(busca);
+      this.carregarContagens();
     });
 
     /** Carrega o tempo de produção configurado no backend */
@@ -148,12 +121,13 @@ export class Lote implements OnInit, OnDestroy {
       this.tick.set(Date.now());
       tickCount++;
 
-      // Realtime Sync Polling: A cada 2 segundos re-valida silenciosamente caso haja lote transicionando ou em produção
-      if (tickCount % 2 === 0) {
-        const precisaSincronizar = this.lotesBase().some(l => l.status === 'em_producao');
-        if (precisaSincronizar) {
+      // Realtime Sync Polling: A cada 5 segundos re-valida silenciosamente caso haja lote em produção
+      if (tickCount % 5 === 0) {
+        const temLoteProduzindo = this.lotes().some(l => l.status === 'em_producao');
+        if (temLoteProduzindo) {
           const buscaAtual = this.route.snapshot.queryParams['busca'];
           this.carregarLotes(buscaAtual, true);
+          this.carregarContagens();
         }
       }
     }, 1000);
@@ -171,22 +145,23 @@ export class Lote implements OnInit, OnDestroy {
       this.erro.set(null);
     }
 
-    // Buscamos SEMPRE todos os lotes para manter as contagens das abas precisas
-    // O filtro de status agora é aplicado localmente via Signal Computed
-    this.loteService.getLotes({})
+    const filtros = {
+      pagina: this.currentPage(),
+      limite: 9, // Layout em grid 3x3
+      status: this.filtroAtivo(),
+      busca: busca || ''
+    };
+
+    this.loteService.getLotes(filtros)
       .pipe(finalize(() => this.carregando.set(false)))
       .subscribe({
-        next: (data) => {
-          if (busca) {
-            const termo = busca.toLowerCase();
-            const filtrados = data.filter(l =>
-              l.numero_lote.toLowerCase().includes(termo) ||
-              l.produto.nome.toLowerCase().includes(termo)
-            );
-            this.lotesBase.set(filtrados);
-          } else {
-            this.lotesBase.set(data);
+        next: (res) => {
+          // Só atualiza o sinal se houver mudança real nos dados (comparação simples de string)
+          // Isso evita que o Angular re-renderize os componentes a cada polling silencioso.
+          if (JSON.stringify(res.itens) !== JSON.stringify(this.lotes())) {
+            this.lotes.set(res.itens);
           }
+          this.paginationMeta.set(res.meta);
         },
         error: (err) => {
           console.error('Erro ao carregar lotes:', err);
@@ -195,13 +170,25 @@ export class Lote implements OnInit, OnDestroy {
       });
   }
 
-  alterarFiltro(status: string): void {
-    this.filtroAtivo.set(status);
-    // Não precisamos chamar carregarLotes() aqui pois o sinal computado 'lotes'
-    // reagirá automaticamente à mudança de filtroAtivo()
+  carregarContagens(): void {
+    this.loteService.getContagem().subscribe({
+      next: (counts) => this.contagemPorStatus.set(counts),
+      error: (err) => console.error('Erro ao carregar contagens:', err)
+    });
+  }
+
+  onPageChange(pagina: number): void {
     this.router.navigate([], {
       relativeTo: this.route,
-      queryParams: { busca: null },
+      queryParams: { pagina },
+      queryParamsHandling: 'merge'
+    });
+  }
+
+  alterarFiltro(status: string): void {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { status, pagina: 1, busca: null },
       queryParamsHandling: 'merge'
     });
   }

--- a/frontend/src/app/features/lote/services/lote.service.ts
+++ b/frontend/src/app/features/lote/services/lote.service.ts
@@ -9,6 +9,16 @@ export interface LoteConfig {
   tempo_producao_minutos: number;
 }
 
+export interface RespostaPaginada<T> {
+  itens: T[];
+  meta: {
+    totalItens: number;
+    itensPorPagina: number;
+    totalPaginas: number;
+    paginaAtual: number;
+  };
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -19,16 +29,22 @@ export class LoteFeatureService {
     return this.http.get<LoteDetalhe>(`${API_URL}/lotes/${id}`);
   }
 
-  getLotes(filtros?: Record<string, string>): Observable<LoteDetalhe[]> {
+  getLotes(filtros?: Record<string, string | number>): Observable<RespostaPaginada<LoteDetalhe>> {
     let params = new HttpParams();
 
     if (filtros) {
       Object.entries(filtros).forEach(([key, value]) => {
-        if (value) params = params.set(key, value);
+        if (value !== undefined && value !== null && value !== '') {
+          params = params.set(key, String(value));
+        }
       });
     }
 
-    return this.http.get<LoteDetalhe[]>(`${API_URL}/lotes`, { params });
+    return this.http.get<RespostaPaginada<LoteDetalhe>>(`${API_URL}/lotes`, { params });
+  }
+
+  getContagem(): Observable<Record<string, number>> {
+    return this.http.get<Record<string, number>>(`${API_URL}/lotes/stats/contagem`);
   }
 
   getProdutos(): Observable<any[]> {

--- a/frontend/src/app/shared/components/lote-card/lote-card.html
+++ b/frontend/src/app/shared/components/lote-card/lote-card.html
@@ -6,18 +6,18 @@
         [style.background-color]="config.cor">
     </div>
 
-    <div class="flex justify-between items-start">
-        <div class="flex flex-col">
-            <h3 class="text-xl font-bold text-white tracking-wider uppercase truncate max-w-[200px]"
+    <div class="flex justify-between items-start gap-3 flex-wrap">
+        <div class="flex flex-col flex-1 min-w-0">
+            <h3 class="text-xl font-bold text-white tracking-wider uppercase truncate"
                 [title]="lote.numero_lote">
                 #{{ lote.numero_lote }}
             </h3>
-            <span class="text-[11px] uppercase tracking-wider mt-0.5 truncate max-w-[180px]" [style.color]="config.cor">
+            <span class="text-[11px] uppercase tracking-wider mt-0.5 truncate" [style.color]="config.cor">
                 {{ lote.produto.nome }}
             </span>
         </div>
 
-        <div class="px-3 py-1 rounded text-[10px] font-bold uppercase tracking-wider shrink-0 border"
+        <div class="px-3 py-1 rounded text-[10px] font-bold uppercase tracking-wider shrink-0 border whitespace-normal sm:whitespace-nowrap max-w-[140px] sm:max-w-none text-center"
             [style.color]="config.cor" [style.border-color]="config.corBorda" [style.background]="config.corBg">
             {{ config.label }}
         </div>

--- a/frontend/src/app/shared/components/lote-card/lote-card.ts
+++ b/frontend/src/app/shared/components/lote-card/lote-card.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnInit, OnDestroy, ChangeDetectorRef, inject } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, OnDestroy, ChangeDetectorRef, inject, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LoteDetalhe, STATUS_CONFIG } from '../../models/lote.models';
 
@@ -7,12 +7,14 @@ import { LoteDetalhe, STATUS_CONFIG } from '../../models/lote.models';
   standalone: true,
   imports: [CommonModule],
   templateUrl: './lote-card.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'block h-full min-w-0'
   }
 })
 export class LoteCardComponent implements OnInit, OnDestroy {
   @Input({ required: true }) lote!: LoteDetalhe;
+  @Input() duracaoProducaoMs: number = 2 * 60 * 1000;
   @Output() cardClick = new EventEmitter<number>();
 
   private cdr = inject(ChangeDetectorRef);
@@ -21,12 +23,10 @@ export class LoteCardComponent implements OnInit, OnDestroy {
   private intervalId: any;
 
   ngOnInit() {
-    // Definimos o progresso logo após a renderização inicial para ativar a transição
-    setTimeout(() => {
-      this.atualizarProgresso();
-    }, 100);
+    // Calcula o progresso inicial imediatamente
+    this.atualizarProgresso();
 
-    // Se estiver em produção, fazemos o "tick" para atualizar a barra e a porcentagem dinamicamente
+    // Se estiver em produção, faz o "tick" a cada segundo
     if (this.lote.status === 'em_producao') {
       this.intervalId = setInterval(() => {
         this.atualizarProgresso();
@@ -45,7 +45,7 @@ export class LoteCardComponent implements OnInit, OnDestroy {
   }
 
   get config() {
-    return STATUS_CONFIG[this.lote.status];
+    return STATUS_CONFIG[this.lote.status] || { label: 'Status', cor: '#fff', corBg: '#000', corBorda: '#fff' };
   }
 
   atualizarProgresso() {
@@ -54,19 +54,21 @@ export class LoteCardComponent implements OnInit, OnDestroy {
       const agora = new Date().getTime();
       const decorrido = agora - inicio;
       
-      // O tempo de produção configurado no backend demo é de 2 minutos (120.000 ms)
-      const tempoTotal = 2 * 60 * 1000;
-      
-      const p = Math.floor((decorrido / tempoTotal) * 100);
+      const p = Math.floor((decorrido / this.duracaoProducaoMs) * 100);
       
       // Limita a barra entre 0 e 99% enquanto o status for 'em_producao'
-      this.animatedProgresso = Math.min(Math.max(p, 0), 99);
+      const novoProgresso = Math.min(Math.max(p, 0), 99);
+      
+      if (this.animatedProgresso !== novoProgresso) {
+        this.animatedProgresso = novoProgresso;
+        this.cdr.markForCheck();
+      }
     } else {
-      this.animatedProgresso = 100;
+      if (this.animatedProgresso !== 100) {
+        this.animatedProgresso = 100;
+        this.cdr.markForCheck();
+      }
     }
-    
-    // Força o Angular a perceber a mudança no setInterval e atualizar a tela imediatamente
-    this.cdr.markForCheck();
   }
 
   get dataFormatada(): string {


### PR DESCRIPTION
 - Migrada a listagem de lotes para paginação server-side com suporte a buscas textuais e filtros por status.
 - Implementado novo endpoint de contagem global para manter as estatísticas das abas e gráfico de carga precisos.
 - Otimizados os cards de lote: agora calculam o progresso em tempo real sem latência inicial e exibem itens vinculados corretamente.
 - Corrigida falha de renderização e melhorado o espaçamento de badges longos no cabeçalho do card.
 - Sincronização automática (polling) recalibrada para maior estabilidade visual e performance.