### PR TITLE
fix: permite cookies cross-origin (SameSite=None) para manter sessao …

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -5,7 +5,7 @@ import jwt from "jsonwebtoken";
 const COOKIE_OPTIONS = {
   httpOnly: true,
   secure: process.env.NODE_ENV === "production",
-  sameSite: "lax" as const,
+  sameSite: process.env.NODE_ENV === "production" ? "none" as const : "lax" as const,
   maxAge: 7 * 24 * 60 * 60 * 1000, // 7 dias
 };
 


### PR DESCRIPTION
…ativa

Altera a politica do cookie de refresh token para SameSite=None quando em ambiente de producao, evitando que o navegador bloqueie o cookie na chamada silenciosa de refresh do Angular apos um F5.